### PR TITLE
revert: docs: assign new issues to tcril-oncall

### DIFF
--- a/.github/ISSUE_TEMPLATE/github-request---generic.md
+++ b/.github/ISSUE_TEMPLATE/github-request---generic.md
@@ -3,7 +3,7 @@ name: GitHub Request - Generic
 about: Make any changes to the openedx organization (grant/revoke user access, change config, etc).
 title: ''
 labels: github-request
-assignees: openedx/tcril-oncall
+assignees: kdmccormick
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/github-request---offboarding.md
+++ b/.github/ISSUE_TEMPLATE/github-request---offboarding.md
@@ -3,7 +3,7 @@ name: GitHub Request - Offboarding
 about: Remove user(s) from the openedx GitHub organization
 title: ''
 labels: github-request
-assignees: openedx/tcril-oncall
+assignees: kdmccormick
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/github-request---onboarding.md
+++ b/.github/ISSUE_TEMPLATE/github-request---onboarding.md
@@ -3,7 +3,7 @@ name: 'GitHub Request - Onboarding'
 about: Add new user(s) to the openedx GitHub organization with appropriate access.
 title: ''
 labels: github-request
-assignees: openedx/tcril-oncall
+assignees: kdmccormick
 
 ---
 


### PR DESCRIPTION
Reverts openedx/tcril-engineering#55

Auto-assigning to a team doesn't seem to work.