### PR TITLE
docs: ask for maintainer when making a new repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-github-request---access.yml
+++ b/.github/ISSUE_TEMPLATE/03-github-request---access.yml
@@ -1,5 +1,5 @@
-name: 🔐 GitHub Request - Access/Config
-description: Make specific changes to the openedx organization (grant/revoke user access, change config, etc).
+name: 🔐 GitHub Request - Repos/Access/Config
+description: Make specific changes to the openedx organization (new repo, grant/revoke user access, change config, etc).
 title: "[GH Request] <ADD A REQUEST TITLE HERE>"
 labels: ["github-request"]
 body:
@@ -31,7 +31,7 @@ body:
     id: request
     attributes:
       label: Requested Change
-      description: Describe what you want changed. If you're referencing users, include both usernames and full names.
+      description: Describe what you want changed. If you're referencing users, include both usernames and full names. If you're requesting a new repo, include who the maintainer will be.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03-github-request---access.yml
+++ b/.github/ISSUE_TEMPLATE/03-github-request---access.yml
@@ -31,7 +31,7 @@ body:
     id: request
     attributes:
       label: Requested Change
-      description: Describe what you want changed. If you're referencing users, include both usernames and full names. If you're requesting a new repo, include who the maintainer will be.
+      description: Describe what you want changed. If you're referencing users, include both usernames and full names. If you're requesting a new repo, include who the maintainer will be and have them comment on this request to confirm their willingness.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
We want new repos to have a committed maintainer. I noted it in our on-call docs as well: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3438903337/On-call+Playbooks#%F0%9F%8C%85-Creating-New-Repos-in-the-openedx-org

Also: It wasn't clear to me whether new repos would be a "GitHub - Access/Config Request" or a "System Request - Misc", so I chose the former and tried to make it clearer.

