### PR TITLE
docs: ask for maintainer when making a new repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-systems-request---uncategorized.yml
+++ b/.github/ISSUE_TEMPLATE/04-systems-request---uncategorized.yml
@@ -37,7 +37,7 @@ body:
     id: reason
     attributes:
       label: Reasoning
-      description: Describe why you want this change to be made.
+      description: Describe why you want this change to be made. If you're requesting a new repo: name its maintainer, and have them comment here to confirm.
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
We want new repos to have a committed maintainer. I noted it in our on-call docs as well: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3438903337/On-call+Playbooks#%F0%9F%8C%85-Creating-New-Repos-in-the-openedx-org