### PR TITLE
Enable blank issues in issue template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 💬 Open edX Community Support
     url: https://discuss.openedx.org/


### PR DESCRIPTION
**PR change:** Enabling blank issues in issue template configuration

**Reason:** As per direction of @feanil; @openedx/axim-aximprovements team would like to use this repository to create smaller stories, while keeping the epic-level stories within their respective repositories.
Creating stories for smaller tasks will help the team in continuous grooming of tickets and provide visibility.