### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/add-6-month-confluence-suspend.yml
+++ b/.github/workflows/add-6-month-confluence-suspend.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/add-GHrequest-to-team-board.yml
+++ b/.github/workflows/add-GHrequest-to-team-board.yml
@@ -27,7 +27,7 @@ jobs:
     if: ${{ !contains(github.event.issue.labels.*.name, 'github-request') }}
     steps:
       - name: apply github-request label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           labels: github-request
 
@@ -42,7 +42,7 @@ jobs:
 
       - name:  Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/add-quarterly-GH-audit.yml
+++ b/.github/workflows/add-quarterly-GH-audit.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name:  Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/add-quarterly-repo-checks.yml
+++ b/.github/workflows/add-quarterly-repo-checks.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name:  Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/add-quarterly-slack-invite.yml
+++ b/.github/workflows/add-quarterly-slack-invite.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name:  Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action

--- a/.github/workflows/add-weekly-gh-requests.yml
+++ b/.github/workflows/add-weekly-gh-requests.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name:  Send custom JSON data to Slack workflow
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
           webhook-type: webhook-trigger
           # This data can be any valid JSON from a previous step in the GitHub Action


### PR DESCRIPTION
## Summary

- Pins all pinnable GitHub Action \`uses:\` refs to full commit SHAs with human-readable version comments
- Generated using [pinact](https://github.com/suzuki-shunsuke/pinact) v3.10.0

## Context

Part of the org-wide SHA-pinning migration: openedx/.github#165

Reusable workflow calls (\`openedx/.github/.github/workflows/...@master\`) are intentionally left unpinned — they track the org's shared workflows by design.

## Test plan

- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nResolves https://github.com/openedx/.github/issues/165